### PR TITLE
change policy to 2k threshold

### DIFF
--- a/kind/policy.yaml
+++ b/kind/policy.yaml
@@ -14,10 +14,10 @@ spec:
     diagnosers:
       - type: PROCESSING_RATE_SCALE_UP
         processingRateScaleUp:
-          rate: 15
+          rate: 2000
           windowMs: 15000
       - type: PROCESSING_RATE_SCALE_DOWN
         processingRateScaleDown:
-          rate: 7
+          rate: 1000
           windowMs: 15000
 


### PR DESCRIPTION
![image](https://github.com/responsivedev/examples/assets/3172405/a99bef33-27fe-4937-bf0b-ae1cce90189f)

The wordcount application has a 1:10 fanout when it does the line splitting so we should account the policy for that as well.