### PR TITLE
Add support for scylla

### DIFF
--- a/kind/kafka.yaml
+++ b/kind/kafka.yaml
@@ -1,0 +1,109 @@
+######################################
+# Self-contained KRaft Broker
+######################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-broker
+  namespace: responsive
+  labels:
+    app: kafka-broker
+spec:
+  ports:
+    - port: 9092
+      name: broker
+    - port: 9093
+      name: controller
+    - port: 29092
+      name: internal
+  selector:
+    app: kafka-broker
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kafka-data-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: /data/kafka
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: responsive
+  name: kafka-broker
+  labels:
+    app: kafka-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-broker
+  template:
+    metadata:
+      labels:
+        app: kafka-broker
+    spec:
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.7.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLUSTER_ID
+              value: "jHS82zyorYvKMntfzD4XRQ"
+            - name: KAFKA_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_LISTENERS
+              value: "INTER_BROKER://:29092,PUBLIC://:9092,CONTROLLER://:9093"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "INTER_BROKER:PLAINTEXT,PUBLIC:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INTER_BROKER://kafka-broker:29092,PUBLIC://kafka-broker:9092"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTER_BROKER"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS
+              value: "1000"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
+          volumeMounts:
+            - name: "kafka-data-dir"
+              mountPath: "/var/lib/kafka/data"
+      volumes:
+        - name: "kafka-data-dir"
+          persistentVolumeClaim:
+            claimName: kafka-data-pvc
+
+    

--- a/kind/mongodb.yaml
+++ b/kind/mongodb.yaml
@@ -1,0 +1,74 @@
+######################
+# On-Cluster MongoDB #
+######################
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+  namespace: responsive
+  labels:
+    app: mongo
+spec:
+  ports:
+    - port: 27017
+      name: main
+      protocol: TCP
+  selector:
+    app: mongo
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mongo-data-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: /data/mongo
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mongo-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "mongo"
+  namespace: responsive
+spec:
+  selector:
+    matchLabels:
+      app: "mongo"
+  replicas: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: "mongo"
+    spec:
+      containers:
+        - name: "mongo"
+          image: mongo:7.0.2
+          imagePullPolicy: IfNotPresent
+          args: [ "--dbpath", "/data/db" ]
+          volumeMounts:
+            - name: "mongo-data-dir"
+              mountPath: "/data/db"
+      volumes:
+        - name: "mongo-data-dir"
+          persistentVolumeClaim:
+            claimName: mongo-data-pvc

--- a/kind/scylladb.yaml
+++ b/kind/scylladb.yaml
@@ -1,0 +1,189 @@
+######################################
+# Self-contained Kafka Broker and ZK #
+######################################
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka-broker
+  namespace: responsive
+  labels:
+    app: kafka-broker
+spec:
+  ports:
+    - port: 9092
+      name: broker
+    - port: 9093
+      name: controller
+    - port: 29092
+      name: internal
+  selector:
+    app: kafka-broker
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kafka-data-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: /data/kafka
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: responsive
+  name: kafka-broker
+  labels:
+    app: kafka-broker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka-broker
+  template:
+    metadata:
+      labels:
+        app: kafka-broker
+    spec:
+      containers:
+        - name: kafka
+          image: confluentinc/cp-kafka:7.7.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: CLUSTER_ID
+              value: "jHS82zyorYvKMntfzD4XRQ"
+            - name: KAFKA_PROCESS_ROLES
+              value: "controller,broker"
+            - name: KAFKA_NODE_ID
+              value: "1"
+            - name: KAFKA_LISTENERS
+              value: "INTER_BROKER://:29092,PUBLIC://:9092,CONTROLLER://:9093"
+            - name: KAFKA_CONTROLLER_LISTENER_NAMES
+              value: "CONTROLLER"
+            - name: KAFKA_CONTROLLER_QUORUM_VOTERS
+              value: "1@localhost:9093"
+            - name: KAFKA_LISTENER_SECURITY_PROTOCOL_MAP
+              value: "INTER_BROKER:PLAINTEXT,PUBLIC:PLAINTEXT,CONTROLLER:PLAINTEXT"
+            - name: KAFKA_ADVERTISED_LISTENERS
+              value: "INTER_BROKER://kafka-broker:29092,PUBLIC://kafka-broker:9092"
+            - name: KAFKA_INTER_BROKER_LISTENER_NAME
+              value: "INTER_BROKER"
+            - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_MIN_ISR
+              value: "1"
+            - name: KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR
+              value: "1"
+            - name: KAFKA_LOG_RETENTION_CHECK_INTERVAL_MS
+              value: "1000"
+            - name: KAFKA_AUTO_CREATE_TOPICS_ENABLE
+              value: "false"
+          volumeMounts:
+            - name: "kafka-data-dir"
+              mountPath: "/var/lib/kafka/data"
+      volumes:
+        - name: "kafka-data-dir"
+          persistentVolumeClaim:
+            claimName: kafka-data-pvc
+
+---
+
+######################
+# On-Cluster ScyllaDB #
+######################
+apiVersion: v1
+kind: Service
+metadata:
+  name: scylladb
+  namespace: responsive
+  labels:
+    app: scylladb
+spec:
+  ports:
+    - port: 9042
+      name: cql
+      protocol: TCP
+    - port: 7199
+      name: jmx
+      protocol: TCP
+    - port: 7000
+      name: transport
+      protocol: TCP
+  selector:
+    app: scylladb
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: scylladb-data-pv
+spec:
+  accessModes:
+    - ReadWriteOnce
+  capacity:
+    storage: 10Gi
+  hostPath:
+    path: /data/scylladb
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: scylladb-data-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi
+
+---
+apiVersion: "apps/v1"
+kind: "Deployment"
+metadata:
+  name: "scylladb"
+  namespace: responsive
+spec:
+  selector:
+    matchLabels:
+      app: "scylladb"
+  replicas: 1
+  minReadySeconds: 5
+  template:
+    metadata:
+      labels:
+        app: "scylladb"
+    spec:
+      containers:
+        - name: "scylladb"
+          image: "bitnami/scylladb:latest"
+          imagePullPolicy: IfNotPresent
+          volumeMounts:
+            - name: "scylladb-data-dir"
+              mountPath: "/bitnami/scylladb"
+      volumes:
+        - name: "scylladb-data-dir"
+          persistentVolumeClaim:
+            claimName: scylladb-data-pvc


### PR DESCRIPTION
This patch modifies the kind configuration to support creation of scylladb storage as well as mongo using the `STATE_STORE_DB` environment variable. The default is mongodb if the variable is not overridden.